### PR TITLE
fix(Dockerfile): update the Dockerfile to include the fixed libtasn1 version 4.21.0-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN apk add --no-cache \
         tar \
         wget \
         xmlstarlet \
-        c-ares=1.34.6-r0
+        c-ares=1.34.6-r0 \
+        libtasn1=4.21.0-r0
 
 COPY settings.xml download.sh cibseven-run.sh cibseven-tomcat.sh cibseven-wildfly.sh  /tmp/
 
@@ -76,6 +77,7 @@ RUN apk add --no-cache \
         tini \
         xmlstarlet \
         c-ares=1.34.6-r0 \
+        libtasn1=4.21.0-r0 \
     && curl -o /usr/local/bin/wait-for-it.sh \
       "https://raw.githubusercontent.com/vishnubob/wait-for-it/a454892f3c2ebbc22bd15e446415b8fcb7c1cfa4/wait-for-it.sh" \
     && chmod +x /usr/local/bin/wait-for-it.sh


### PR DESCRIPTION
https://helpdesk.cib.de/browse/CIB7-981