### PR TITLE
chore(security): CVE-fixes removed after alpine update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,7 @@ RUN apk add --no-cache \
         maven \
         tar \
         wget \
-        xmlstarlet \
-        c-ares=1.34.6-r0 \
-        libtasn1=4.21.0-r0 \
-        libcrypto3=3.5.5-r0 \
-        libssl3=3.5.5-r0
+        xmlstarlet
 
 COPY settings.xml download.sh cibseven-run.sh cibseven-tomcat.sh cibseven-wildfly.sh  /tmp/
 
@@ -78,10 +74,6 @@ RUN apk add --no-cache \
         tzdata \
         tini \
         xmlstarlet \
-        c-ares=1.34.6-r0 \
-        libtasn1=4.21.0-r0 \
-        libcrypto3=3.5.5-r0 \
-        libssl3=3.5.5-r0 \
     && curl -o /usr/local/bin/wait-for-it.sh \
       "https://raw.githubusercontent.com/vishnubob/wait-for-it/a454892f3c2ebbc22bd15e446415b8fcb7c1cfa4/wait-for-it.sh" \
     && chmod +x /usr/local/bin/wait-for-it.sh


### PR DESCRIPTION
Removed unnecessary dependencies from the Dockerfile.

Previously needed update of the packages removed, that has been fixed with new alpine version or jdk update.