### PR TITLE
feat(wildfly): add AI_AGENT_ENABLED toggle for the ai-agent module (CIB7-1445)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ we will not provide ready to use images for them.
 
 To override the default Java options the environment variable `JAVA_OPTS` can be set.
 For the `wildfly` distribution, the default `JAVA_OPTS` are
-`-Xms512m -Xmx1024m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=512m`.
+`-Xms512m -Xmx1024m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=1024m`.
 
 For the `wildfly` distribution, the environment variable
 `WILDFLY_MANAGEMENT_BLOCKING_TIMEOUT` controls the

--- a/cibseven-wildfly.sh
+++ b/cibseven-wildfly.sh
@@ -60,7 +60,10 @@ export JBOSS_MODULES_SYSTEM_PKGS=${JBOSS_MODULES_SYSTEM_PKGS:-"org.jboss.byteman
 # Ensure wildfly binds to public interface, preferes IPv4 and runs in the background
 export PREPEND_JAVA_OPTS="-Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0 -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Djboss.modules.system.pkgs=${JBOSS_MODULES_SYSTEM_PKGS} -Djboss.as.management.blocking.timeout=${WILDFLY_MANAGEMENT_BLOCKING_TIMEOUT:-600}"
 export LAUNCH_JBOSS_IN_BACKGROUND=TRUE
-export JAVA_OPTS="${JAVA_OPTS:-"-Xms512m -Xmx1024m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=512m"}"
+# MaxMetaspaceSize=1024m gives the optional ai-agent connector (LangChain4j/ONNX,
+# which load many classes) room to avoid OutOfMemoryError: Metaspace. Matches the
+# distribution's standalone.conf default. (CIB7-1445)
+export JAVA_OPTS="${JAVA_OPTS:-"-Xms512m -Xmx1024m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=1024m"}"
 
 CMD="/camunda/bin/standalone.sh"
 

--- a/cibseven-wildfly.sh
+++ b/cibseven-wildfly.sh
@@ -83,6 +83,17 @@ wait_for_it
 # Use existing wildfly distribution if present..
 JBOSS_HOME="${JBOSS_HOME:-/camunda}"
 
+# AI Agent connector toggle: the ai-agent module ships active-by-default (imported
+# by the cibseven-engine-plugin-connect module). Setting AI_AGENT_ENABLED=false
+# removes that import so the connector is not loaded -- the module dir and its jars
+# stay in place (non-destructive). The import is declared optional in module.xml,
+# so the engine boots cleanly either way.
+if [ "${AI_AGENT_ENABLED:-true}" = "false" ]; then
+  echo "AI_AGENT_ENABLED=false -> disabling ai-agent connector (removing module import)"
+  sed -i '/cibseven-connect-ai-agent/d' \
+    "$JBOSS_HOME/modules/org/cibseven/bpm/cibseven-engine-plugin-connect/main/module.xml"
+fi
+
 # Define the target file path
 FILE="$JBOSS_HOME/modules/org/cibseven/config/main/cibseven-webclient.properties"
 


### PR DESCRIPTION
## What & why

Companion to the cibseven WildFly PR (CIB7-1445), which ships the ai-agent connector as a JBoss module imported by `cibseven-engine-plugin-connect` (active by default). This adds a runtime switch to turn it off.

## Change
- **cibseven-wildfly.sh**: when `AI_AGENT_ENABLED=false`, `sed` removes the ai-agent import line from `${JBOSS_HOME}/modules/org/cibseven/bpm/cibseven-engine-plugin-connect/main/module.xml` at startup. The module dir + jars stay in place (non-destructive); the import is declared `optional` in module.xml so the engine boots cleanly either way.

Same `AI_AGENT_ENABLED` env var used by the tomcat/run images. Draft — pairs with the cibseven + webclient PRs, pending a real WildFly boot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)