### PR TITLE
fix(docker): entrypoint script cleanups during 2.2.0 QA (CIB7-1462)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,12 @@ ENV AI_AGENT_ENABLED=true
 ENV JAVA_OPTS=""
 ENV WILDFLY_MANAGEMENT_BLOCKING_TIMEOUT=600
 
+# OpenTelemetry Java agent toggle (opt-in). When false (the default) the agent is
+# NOT attached on Tomcat/WildFly, mirroring the pre-2.x JMX_PROMETHEUS=false default.
+# Set OTEL_AGENT_ENABLED=true to load the agent and configure exporters via OTEL_* below.
+# (The Spring Boot run/run4 distributions always load the agent via JAVA_OPTS.)
+ENV OTEL_AGENT_ENABLED=false
+
 # OpenTelemetry default exporter settings (all exporters disabled, user must configure)
 # Note: The OTEL agent is loaded via server-specific variables (PREPEND_JAVA_OPTS for WildFly,
 # CATALINA_OPTS for Tomcat) to avoid affecting CLI tools like jboss-cli.sh

--- a/README.md
+++ b/README.md
@@ -286,7 +286,12 @@ This is only supported for `wildfly` and `tomcat` distributions.
 
 ### OpenTelemetry Agent
 
-The CIB seven Docker images come with OpenTelemetry Java-Agent pre-installed. The agent automatically instruments your application to generate telemetry data (metrics, traces, and logs), but all exporters are disabled by default. You need to configure at least one exporter to provide telemetry data.
+The CIB seven Docker images come with the OpenTelemetry Java-Agent pre-installed. When loaded, the agent automatically instruments your application to generate telemetry data (metrics, traces, and logs), but all exporters are disabled by default. You need to configure at least one exporter to provide telemetry data.
+
+**Loading the agent:**
+
+* On the `tomcat` and `wildfly` distributions the agent is **opt-in**: set `OTEL_AGENT_ENABLED=true` to attach it (default: `false`). This mirrors the pre-2.x `JMX_PROMETHEUS` behavior and avoids the agent's startup cost when telemetry is not needed.
+* On the Spring Boot `run` and `run4` distributions the agent is always loaded (it stays inert until an exporter is configured), so `OTEL_AGENT_ENABLED` has no effect there.
 
 #### Configuration
 
@@ -294,6 +299,7 @@ The OpenTelemetry Agent can be configured using environment variables.
 
 **Pre-configured Environment Variables (from Dockerfile):**
 
+* `OTEL_AGENT_ENABLED`: Attach the OpenTelemetry agent on `tomcat`/`wildfly` (default: `false`; no effect on `run`/`run4`, which always load it)
 * `OTEL_SERVICE_NAME`: Service name for telemetry data (default: `cibseven`)
 * `OTEL_METRICS_EXPORTER`: Configure metrics exporter (default: `none`, examples: `prometheus`, `otlp`)
 * `OTEL_TRACES_EXPORTER`: Configure traces exporter (default: `none`, example: `otlp`)
@@ -323,6 +329,7 @@ You can add custom JMX metrics by mounting your own configuration file to `/camu
 
 ```bash
 docker run -d --name cibseven -p 8080:8080 -p 9464:9464 \
+           -e OTEL_AGENT_ENABLED=true \
            -e OTEL_METRICS_EXPORTER=prometheus \
            -e OTEL_EXPORTER_PROMETHEUS_PORT=9464 \
            -v $(pwd)/my_custom_jmx_config.yaml:/camunda/javaagent/jmx_custom_config.yaml \

--- a/cibseven-run.sh
+++ b/cibseven-run.sh
@@ -30,6 +30,11 @@ if [[ -z "${SPRING_DATASOURCE_URL:-}" && -n "${DB_URL:-}" ]]; then
   export SPRING_DATASOURCE_URL="${DB_URL}"
 fi
 
+if [ "${DEBUG}" = "true" ]; then
+  echo "Enabling debug mode, JPDA accessible under port 8000"
+  export JAVA_OPTS="${JAVA_OPTS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000"
+fi
+
 # OpenTelemetry Agent configuration
 # Load the agent via JAVA_OPTS instead of JAVA_TOOL_OPTIONS
 export JAVA_OPTS="${JAVA_OPTS:-} -javaagent:/camunda/javaagent/opentelemetry-javaagent-${OPENTELEMETRY_AGENT_VERSION}.jar"

--- a/cibseven-run4.sh
+++ b/cibseven-run4.sh
@@ -35,6 +35,10 @@ if [ "${DEBUG}" = "true" ]; then
   export JAVA_OPTS="${JAVA_OPTS} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000"
 fi
 
+# OpenTelemetry Agent configuration
+# Load the agent via JAVA_OPTS instead of JAVA_TOOL_OPTIONS
+export JAVA_OPTS="${JAVA_OPTS:-} -javaagent:/camunda/javaagent/opentelemetry-javaagent-${OPENTELEMETRY_AGENT_VERSION}.jar"
+
 CMD="/camunda/internal/run.sh start"
 
 wait_for_it

--- a/cibseven-tomcat.sh
+++ b/cibseven-tomcat.sh
@@ -62,9 +62,12 @@ if [ "${DEBUG}" = "true" ]; then
   CMD+=" jpda"
 fi
 
-# OpenTelemetry Agent configuration
+# OpenTelemetry Agent configuration (opt-in, mirrors the old JMX_PROMETHEUS gate)
 # Load the agent via CATALINA_OPTS (Tomcat-specific) instead of JAVA_TOOL_OPTIONS
-export CATALINA_OPTS="${CATALINA_OPTS:-} -javaagent:/camunda/javaagent/opentelemetry-javaagent-${OPENTELEMETRY_AGENT_VERSION}.jar"
+if [ "${OTEL_AGENT_ENABLED:-false}" = "true" ]; then
+  echo "OTEL_AGENT_ENABLED=true -> attaching OpenTelemetry Java agent"
+  export CATALINA_OPTS="${CATALINA_OPTS:-} -javaagent:/camunda/javaagent/opentelemetry-javaagent-${OPENTELEMETRY_AGENT_VERSION}.jar"
+fi
 
 CMD+=" run"
 

--- a/cibseven-wildfly.sh
+++ b/cibseven-wildfly.sh
@@ -86,15 +86,6 @@ wait_for_it
 # Use existing wildfly distribution if present..
 JBOSS_HOME="${JBOSS_HOME:-/camunda}"
 
-# Webclient bean initialization can race with engine schema bootstrap
-# (MOD_ELEMENT_TEMPLATES may not exist yet). Lazy-init avoids this startup race
-# and still keeps the AI agent path enabled. This applies to all architectures
-# since the timing issue can occur on both arm64 and amd64.
-if [ "${AI_AGENT_ENABLED:-true}" = "true" ]; then
-  echo "AI_AGENT_ENABLED=true -> enabling Spring lazy initialization"
-  export SPRING_MAIN_LAZY_INITIALIZATION="${SPRING_MAIN_LAZY_INITIALIZATION:-true}"
-fi
-
 # AI Agent connector toggle: the ai-agent module ships active-by-default (imported
 # by the cibseven-engine-plugin-connect module). Setting AI_AGENT_ENABLED=false
 # removes that import so the connector is not loaded -- the module dir and its jars

--- a/cibseven-wildfly.sh
+++ b/cibseven-wildfly.sh
@@ -55,7 +55,14 @@ if [ -z "$SKIP_DB_CONFIG" ]; then
 fi
 
 # See https://issues.jboss.org/browse/LOGMGR-218
-export JBOSS_MODULES_SYSTEM_PKGS=${JBOSS_MODULES_SYSTEM_PKGS:-"org.jboss.byteman,org.jboss.logmanager"}
+# org.jboss.logmanager is only required as a system package for the OpenTelemetry
+# agent's LogManager bootclasspath workaround below, so add it only when the agent
+# is enabled (mirrors the old JMX_PROMETHEUS gate).
+if [ "${OTEL_AGENT_ENABLED:-false}" = "true" ]; then
+  export JBOSS_MODULES_SYSTEM_PKGS=${JBOSS_MODULES_SYSTEM_PKGS:-"org.jboss.byteman,org.jboss.logmanager"}
+else
+  export JBOSS_MODULES_SYSTEM_PKGS=${JBOSS_MODULES_SYSTEM_PKGS:-"org.jboss.byteman"}
+fi
 
 # Ensure wildfly binds to public interface, preferes IPv4 and runs in the background
 export PREPEND_JAVA_OPTS="-Djboss.bind.address=0.0.0.0 -Djboss.bind.address.management=0.0.0.0 -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -Djboss.modules.system.pkgs=${JBOSS_MODULES_SYSTEM_PKGS} -Djboss.as.management.blocking.timeout=${WILDFLY_MANAGEMENT_BLOCKING_TIMEOUT:-600}"
@@ -72,14 +79,18 @@ if [ "${DEBUG}" = "true" ]; then
   CMD+=" --debug *:8000"
 fi
 
-# JBoss LogManager configuration for OpenTelemetry
-# See https://github.com/prometheus/jmx_exporter/issues/344
-LOG_MANAGER_PATH=$(find /camunda/modules -name "jboss-logmanager*.jar")
-COMMON_PATH=$(find /camunda/modules -name "wildfly-common*.jar")
-SMALLRYE_OS_PATH=$(find /camunda/modules -name "smallrye-common-os*.jar")
-SMALLRYE_NET_PATH=$(find /camunda/modules -name "smallrye-common-net*.jar")
-export PREPEND_JAVA_OPTS="${PREPEND_JAVA_OPTS} -Dsun.util.logging.disableCallerCheck=true -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Xbootclasspath/a:$LOG_MANAGER_PATH:$COMMON_PATH:$SMALLRYE_OS_PATH:$SMALLRYE_NET_PATH"
-export PREPEND_JAVA_OPTS="${PREPEND_JAVA_OPTS} -javaagent:/camunda/javaagent/opentelemetry-javaagent-${OPENTELEMETRY_AGENT_VERSION}.jar"
+# OpenTelemetry agent (opt-in, mirrors the old JMX_PROMETHEUS gate)
+if [ "${OTEL_AGENT_ENABLED:-false}" = "true" ]; then
+  echo "OTEL_AGENT_ENABLED=true -> attaching OpenTelemetry Java agent"
+  # JBoss LogManager configuration for OpenTelemetry
+  # See https://github.com/prometheus/jmx_exporter/issues/344
+  LOG_MANAGER_PATH=$(find /camunda/modules -name "jboss-logmanager*.jar")
+  COMMON_PATH=$(find /camunda/modules -name "wildfly-common*.jar")
+  SMALLRYE_OS_PATH=$(find /camunda/modules -name "smallrye-common-os*.jar")
+  SMALLRYE_NET_PATH=$(find /camunda/modules -name "smallrye-common-net*.jar")
+  export PREPEND_JAVA_OPTS="${PREPEND_JAVA_OPTS} -Dsun.util.logging.disableCallerCheck=true -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Xbootclasspath/a:$LOG_MANAGER_PATH:$COMMON_PATH:$SMALLRYE_OS_PATH:$SMALLRYE_NET_PATH"
+  export PREPEND_JAVA_OPTS="${PREPEND_JAVA_OPTS} -javaagent:/camunda/javaagent/opentelemetry-javaagent-${OPENTELEMETRY_AGENT_VERSION}.jar"
+fi
 
 wait_for_it
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -87,6 +87,8 @@ services:
         image: cibseven/cibseven:${IMAGE_TAG:-${DISTRO}-${PLATFORM}}
         platform: linux/${PLATFORM}
         environment:
+            # OTel agent is opt-in on tomcat/wildfly (no-op on run/run4, which always load it)
+            - OTEL_AGENT_ENABLED=true
             - OTEL_METRICS_EXPORTER=prometheus
             - OTEL_LOGS_EXPORTER=none
             - OTEL_TRACES_EXPORTER=otlp


### PR DESCRIPTION
## Summary

Container entrypoint-script cleanups surfaced during CIB seven 2.2.0 QA.

### 1. Spring Boot `run`/`run4` DEBUG + OTel parity

`cibseven-run.sh` and `cibseven-run4.sh` had drifted apart; both now follow the same `datasource → DEBUG → OTel → CMD` structure:

- **`cibseven-run.sh`**: add the `DEBUG=true` block appending `-agentlib:jdwp=...address=*:8000` to `JAVA_OPTS` (previously had the OTel agent but no debug support).
- **`cibseven-run4.sh`**: add `-javaagent:.../opentelemetry-javaagent-${OPENTELEMETRY_AGENT_VERSION}.jar` to `JAVA_OPTS` (previously had debug but no OTel agent).

### 2. Drop the WildFly `SPRING_MAIN_LAZY_INITIALIZATION` workaround

The Spring lazy-init block in `cibseven-wildfly.sh` (added in #37/#38) was a stop-gap for the WildFly webclient bean initialization racing with engine schema bootstrap (`MOD_ELEMENT_TEMPLATES` not yet present). That race is now handled in the application itself, tuned via `WILDFLY_MANAGEMENT_BLOCKING_TIMEOUT` (`jboss.as.management.blocking.timeout`, default 600s), so the docker-level workaround is removed.

### 3. Make the Tomcat/WildFly OpenTelemetry agent opt-in (`OTEL_AGENT_ENABLED`)

Before #9, the Prometheus JMX exporter agent was attached on Tomcat/WildFly **only** when `JMX_PROMETHEUS=true` (default `false`). #9 replaced it with the OpenTelemetry agent but dropped the gate, so the agent was loaded unconditionally.

This restores the opt-in behavior with the new agent:

- New `ENV OTEL_AGENT_ENABLED=false` (default off, mirrors the old `JMX_PROMETHEUS=false`).
- **`cibseven-tomcat.sh`**: attach the OTel `-javaagent` to `CATALINA_OPTS` only when `OTEL_AGENT_ENABLED=true`.
- **`cibseven-wildfly.sh`**: attach the OTel `-javaagent` + the LogManager bootclasspath workaround to `PREPEND_JAVA_OPTS` only when enabled, and add `org.jboss.logmanager` to `JBOSS_MODULES_SYSTEM_PKGS` only in that case (matching the old conditional).

**`run`/`run4` are intentionally left unchanged** — they never had a `JMX_PROMETHEUS` gate. Spring Boot exposes metrics natively (Actuator/Micrometer Prometheus registry), so those distros never used the standalone exporter javaagent; the gate was always a Tomcat/WildFly (bare servlet-container) concern. This preserves the historical asymmetry. If we want uniform opt-in across all four distros, `run`/`run4` could be gated too in a follow-up.

## Verification

- `DEBUG`, `OPENTELEMETRY_AGENT_VERSION`, `JAVA_OPTS`, and the new `OTEL_AGENT_ENABLED` all have `ENV` defaults in the shared `Dockerfile`, so the bare expansions stay safe under `set -Eeu`.
- `bash -n` passes on all edited scripts.
- :warning: The lazy-init removal relies on the application-side webclient init fix being present in the cibseven version this image builds — WildFly startup CI on this PR should confirm a clean boot.

Jira: CIB7-1462 (sub-task of CIB7-1443 — CIB seven 2.2.0 QA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)