### PR TITLE
release: publish 2.2.0 release images (SNAPSHOT=false)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM alpine:3.23 as builder
 # Re-declare to use in this stage (inherits the value from global)
 ARG VERSION
 ARG DISTRO=tomcat
-ARG SNAPSHOT=true
+ARG SNAPSHOT=false
 
 ARG USER
 ARG PASSWORD


### PR DESCRIPTION
## CE 2.2.0 Docker release

Flips `ARG SNAPSHOT=true → false` in the Dockerfile. `VERSION` is already `2.2.0`.

With `SNAPSHOT=false`, the publish workflow (`build-test-and-publish.yml`, runs on push to `main`) makes `release.sh` pull the **released** CE 2.2.0 artifacts from the `public` repo and push the release image tags for all distros (tomcat, wildfly, run, run4; multi-arch):
- `<distro>-2.2.0`, `<distro>-latest`, `<distro>`
- and for tomcat: `2.2.0`, `latest`

CE engine + webclient 2.2.0 are on Maven Central / public, so the artifacts resolve.

**Merging this triggers the public image publish.** Post-release (next dev cycle) we revert to `SNAPSHOT=true` and bump `VERSION`.

Part of the CIB seven 2.2.0 platform release — CIB7-1463 (step 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)